### PR TITLE
change of license

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 Resources for MDAnalysis look and feel.
 
-1. logo
-2. colors
-3. templates
+1. [logos](logos/)
+2. [colors](STYLE_GUIDE.md)
+3. [templates](templates/)
 
 Note that *special licenses* apply to all materials. In the absence of
 an explicit license, content is *not licensed for any use outside the
-MDAnalysis organization*. The exception here is all materials in the [templates](templates/) directory, which are licensed openly and permissively for usage.
+MDAnalysis organization*. The exception here is all materials in the
+[templates](templates/) directory, which are licensed openly and
+permissively for usage.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -20,12 +20,12 @@ Analysis
 
 MDAnalysis theme
 
-* MDA orange: #FF9200
-* MDA gray:   #808080
+* MDAnalysis orange: #FF9200
+* MDAnalysis gray:   #808080
 * RTD dark gray: #343131      (from User Guide RTD dark gray)
 * RTD light grey: #E6E6E6
-* MDA black:  #000000
-* MDA white:  #FFFFFF
+* MDAnalysis black:  #000000
+* MDAnalysis white:  #FFFFFF
 
 ### Documentation colors
 

--- a/logos/AUTHOR
+++ b/logos/AUTHOR
@@ -1,16 +1,21 @@
-The MDAnalysis 'Atom' logo was created by Christian Beckstein and is
+The MDAnalysis 'Atom' logo was created by Christian Beckstein
+(@beckstein) in 2011.
 
-Copyright (c) 2011 Christian Beckstein
-
-MDAnalysis Logo 'Atom' by Christian Beckstein is licensed under a
-Creative Commons Attribution-NoDerivs 3.0 Unported License.
-To view a copy of this license, visit
-http://creativecommons.org/licenses/by-nd/3.0/ or send a letter to Creative
-Commons, 444 Castro Street, Suite 900, Mountain View, California, 94041, USA.
+(Prior to 2024-06-21, the MDAnalysis 'Atom' logo was licensed under a
+Creative Commons Attribution-NoDerivs 3.0 Unported License. From this
+date forward the logo and its derivatives may only be used under the
+NumFOCUS trademark guidelines
+https://numfocus.org/trademark-guidelines.)
 
 The logo is contained in the file 'mdanalysis-logo.png'.
 
 Derivatives in the files 'mdanalysis-logo-127x55.png',
 'mdanalysis-logo-200x150.png', 'mdanalysis-logo.ico' were created for
-inclusion in MDAnalysis and on websites related to MDAnalysis. They
-are distributed under the same license as the 'Atom' logo.
+inclusion in MDAnalysis and on websites related to MDAnalysis.
+
+
+
+The 'MDAKits Registry' logo and its derivatives were created by Lily
+Wang (@lilyminium) in 2024 by incorporating the 'Atom' logo into
+original art. The 'MDAKits Registry' logo files are stored in the
+directory `MDAKits/MDAKits-registry`.

--- a/logos/LICENSE
+++ b/logos/LICENSE
@@ -1,9 +1,17 @@
-MDAnalysis Logo 'Atom' by Christian Beckstein is licensed under a
-Creative Commons Attribution-NoDerivs 3.0 Unported License.
-To view a copy of this license, visit
-http://creativecommons.org/licenses/by-nd/3.0/ or send a letter to Creative
-Commons, 444 Castro Street, Suite 900, Mountain View, California, 94041, USA.
+NumFOCUS https://numfocus.org/ as the fiscal sponsor of the MDAnalysis Project holds all
+rights for all logos in the `logos` directory.
 
-The MDAKits Registry logo by Lily Wang is a
-derivative of the 'Atom' logo and falls under the same
-license.
+Logos may only be used outside of the MDAnalysis project in compliance
+with NumFOCUS's Trademark Guidelines as written on the web page
+https://numfocus.org/trademark-guidelines
+
+
+For further information please contact NumFOCUS
+
+  NumFOCUS
+  P.O. Box 90596
+  Austin, TX 78709
+  info@numfocus.org
+  +1 ​(512) 831-2870
+
+

--- a/logos/README.md
+++ b/logos/README.md
@@ -1,22 +1,27 @@
-# MDAnalysis Logo
+# MDAnalysis Project Logos and Logo Art
 
-The MDAnalysis 'Atom' logo was created by Christian Beckstein and is
-Copyright (c) 2011 Christian Beckstein (@beckstein) (see
-[AUTHOR](AUTHOR)).
+The `logos` directory contains logos and logo art that identifies
+MDAnalysis. These files **should only be used inside the MDAnalysis
+project**.
+
+[NumFOCUS](https://numfocus.org/) as the fiscal sponsor of MDAnalysis
+holds all rights on the logos and any future derivatives. See the file
+[LICENSE](LICENSE) for more details.
+
+
+
+## MDAnalysis Logo
+
+The MDAnalysis 'Atom' logo was created by Christian Beckstein
+(@beckstein) in 2011 (see [AUTHOR](AUTHOR)).
 
 
 The typeface is "ZAG Bold" from https://www.dafont.com/de/zag.font
 (see
 [MDAnalysis/UserGuide#11](https://github.com/MDAnalysis/UserGuide/pull/11#issuecomment-535663213)).
 
-MDAKits logos are contained in the MDAKits directory.
 
-The [MDAKits registry logo](MDAKits/MDAKits-registry/)
-was created by Lily Wang (@lilyminium) in 2024 as
-a derivative of the original MDAnalysis Atom logo. 
-It may only be used under the same license and rules as the original logo.
-
-## Original logo files
+### Original logo files
 
 Original logos are in the PDF files
 * `mdanalysis-logo.pdf` (rectangle)
@@ -26,7 +31,7 @@ Either logo can be used to represent the project. Use the one that
 fits better.
 
 
-## Rastered logos
+### Rastered logos
 
 Rastered versions at different resolution were generated from the
 original PDFs and provided in the *rastered/* directory. 
@@ -35,11 +40,24 @@ original PDFs and provided in the *rastered/* directory.
 * background: white, transparent
 
 
-## Icons
+### Icons
 
 In order to represent MDAnalysis in a browser bar or as a tile on a
 smart phone, we provide specialized icon files in une the *icons/*
 directory.
+
+
+## MDAKits logo
+
+
+The 'MDAKits Registry' logo was created by Lily Wang (@lilyminium) in
+2024 as a derivative of the original MDAnalysis 'Atom' logo (see
+[AUTHOR](AUTHOR)). It is used for the [MDAKits
+Registry](https://mdakits.mdanalysis.org/).
+
+Logo files are available in the
+[logos/MDAKits/MDAKits-registry](MDAKits/MDAKits-registry) directory.
+
 
 
 

--- a/logos/README.md
+++ b/logos/README.md
@@ -25,7 +25,7 @@ The typeface is "ZAG Bold" from https://www.dafont.com/de/zag.font
 
 Original logos are in the PDF files
 * `mdanalysis-logo.pdf` (rectangle)
-* `mdanalysis-logo_square` (square)
+* `mdanalysis-logo_square.pdf` (square)
 
 Either logo can be used to represent the project. Use the one that
 fits better.
@@ -57,6 +57,9 @@ Registry](https://mdakits.mdanalysis.org/).
 
 Logo files are available in the
 [logos/MDAKits/MDAKits-registry](MDAKits/MDAKits-registry) directory.
+
+
+
 
 
 


### PR DESCRIPTION
- As of 2024-06-21, NumFOCUS holds all rights on the MDAnalysis logos and any future logos that the project creates for itself.
- Removed the CC-BY-ND license from the MDAnalysis Atom logo.
- Made clear that all logos (Atom, MDAKit Registry) now can only be used outside MDA when following https://numfocus.org/trademark-guidelines
- updated READMEs with links
- close #6